### PR TITLE
Adds support for specifying default attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ export default defineConfig({
 });
 ```
 
+### Setting default attributes
+
+You can pass default attributes that will apply to all markdown and mdx images:
+
+```js
+import { defineConfig } from 'astro/config';
+import imgAttr from 'remark-imgattr';
+
+// https://astro.build/config
+export default defineConfig({
+	markdown: {
+		remarkPlugins:[
+			[imgAttr, { defaults: { width: 700, format: 'avif' } }],
+		],
+	},
+});
+```
+
+If an image specifies the same attributes as `defaults`, the image’s value for that attribute will be used instead of the default value.
+
 ## Example
 
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 /**
  * Plugin to parse and transform image attributes in a markdown abstract syntax tree.
+ * @param {{ defaults?: Record<string, any> | undefined }} [options] - Optional configuration object.
  * @returns {Function} A transformer function to apply on the syntax tree.
  */
-export default function imgAttr() {
+export default function imgAttr({ defaults = {} } = {}) {
 
   /**
    * Checks if a string is a valid attribute string.
@@ -19,9 +20,14 @@ export default function imgAttr() {
    * @returns {Object} The parsed attributes as an object.
    */
   function parseAttributes(attrString) {
+    const attributes = { ...defaults };
+
+    if (!isAttributeString(attrString)) {
+      return attributes;
+    }
+
     attrString = attrString.slice(1, -1).trim(); // Remove the leading and trailing parentheses.
 
-    const attributes = {};
     let currentKey = '';
     let currentValue = '';
     let inQuotes = false;
@@ -152,11 +158,9 @@ export default function imgAttr() {
             j++;
           }
 
-          if (isAttributeString(attributeString)) {
-            const attrs = parseAttributes(attributeString);
-            currentNode.data.hProperties = attrs;
-            node.children.splice(i + 1, j - i);
-          }
+          const attrs = parseAttributes(attributeString);
+          currentNode.data.hProperties = attrs;
+          node.children.splice(i + 1, j - i);
         }
 
         if (currentNode.children && currentNode.children.length) {

--- a/test/fixtures/defaults.md
+++ b/test/fixtures/defaults.md
@@ -1,0 +1,9 @@
+# Default Attributes Test
+
+An image with no attributes that will receive default attributes:
+
+![Alt text](./image.jpg)
+
+An image with attributes that will receive default attributes but override them with locally defined attributes:
+
+![Loading eager](./image.jpg)(loading: eager)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,12 +7,13 @@ import imgAttr from '../index.js';
 /**
  * Process markdown through the unified pipeline with imgAttr plugin
  * @param {string} markdown - The markdown content to process
+ * @param {object} [defaults] - Optional default attributes for images
  * @returns {Promise<string>} The resulting HTML
  */
-export async function processMarkdown(markdown) {
+export async function processMarkdown(markdown, defaults) {
   const result = await unified()
     .use(remarkParse)
-    .use(imgAttr)
+    .use(imgAttr, defaults)
     .use(remarkRehype)
     .use(rehypeStringify)
     .process(markdown);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,13 +7,13 @@ import imgAttr from '../index.js';
 /**
  * Process markdown through the unified pipeline with imgAttr plugin
  * @param {string} markdown - The markdown content to process
- * @param {object} [defaults] - Optional default attributes for images
+ * @param {Record<string, any>} [defaults] - Optional default attributes for images
  * @returns {Promise<string>} The resulting HTML
  */
 export async function processMarkdown(markdown, defaults) {
   const result = await unified()
     .use(remarkParse)
-    .use(imgAttr, defaults)
+    .use(imgAttr, { defaults })
     .use(remarkRehype)
     .use(rehypeStringify)
     .process(markdown);

--- a/test/integration/defaults.test.js
+++ b/test/integration/defaults.test.js
@@ -1,0 +1,42 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'fs/promises';
+import { parse } from 'node-html-parser';
+import { processMarkdown } from '../helpers.js';
+
+describe('Default Attributes', () => {
+	test('should apply no attributes when defaults is empty', async () => {
+		const markdown = await readFile('test/fixtures/defaults.md', 'utf-8');
+		const html = await processMarkdown(markdown, {});
+		const root = parse(html);
+		const img = root.querySelector('img[alt="Alt text"]');
+
+		// Find the image with alt "Alt text"
+		assert.ok(img, 'Image with alt "Alt text" should exist');
+		assert.deepEqual(Object.keys(img.attributes), ['src', 'alt']);
+	});
+
+	test('should apply default attributes', async () => {
+		const markdown = await readFile('test/fixtures/defaults.md', 'utf-8');
+		const html = await processMarkdown(markdown, { loading: 'lazy' });
+		const root = parse(html);
+		const img = root.querySelector('img[alt="Alt text"]');
+
+		// Find the image with alt "Alt text"
+		assert.ok(img, 'Image with alt "Alt text" should exist');
+		assert.deepEqual(Object.keys(img.attributes), ['src', 'alt', 'loading']);
+		assert.strictEqual(img.getAttribute('loading'), 'lazy');
+	});
+
+	test('should not override existing attributes', async () => {
+		const markdown = await readFile('test/fixtures/defaults.md', 'utf-8');
+		const html = await processMarkdown(markdown, { loading: 'lazy' });
+		const root = parse(html);
+		const img = root.querySelector('img[alt="Loading eager"]');
+
+		// Find the image with alt "Loading eager"
+		assert.ok(img, 'Image with alt "Loading eager" should exist');
+		assert.deepEqual(Object.keys(img.attributes), ['src', 'alt', 'loading']);
+		assert.strictEqual(img.getAttribute('loading'), 'eager'); // Should not be overridden
+	});
+});

--- a/test/integration/defaults.test.js
+++ b/test/integration/defaults.test.js
@@ -39,4 +39,17 @@ describe('Default Attributes', () => {
 		assert.deepEqual(Object.keys(img.attributes), ['src', 'alt', 'loading']);
 		assert.strictEqual(img.getAttribute('loading'), 'eager'); // Should not be overridden
 	});
+
+	test('should include default attributes when not overridden', async () => {
+		const markdown = await readFile('test/fixtures/defaults.md', 'utf-8');
+		const html = await processMarkdown(markdown, { loading: 'lazy', width: '800' });
+		const root = parse(html);
+		const img = root.querySelector('img[alt="Loading eager"]');
+
+		// Find the image with alt "Loading eager"
+		assert.ok(img, 'Image with alt "Loading eager" should exist');
+		assert.deepEqual(Object.keys(img.attributes), ['src', 'alt', 'loading', 'width']);
+		assert.strictEqual(img.getAttribute('loading'), 'eager');
+		assert.strictEqual(img.getAttribute('width'), '800');
+	});
 });


### PR DESCRIPTION
Closes #3

Lets people pass a `defaults` option with attributes to apply.

```js
.use(imgAttr, { defaults: { width: 800, style: "border: 1px solid red;" } })
```

```js
markdown: {
	remarkPlugins:[
		[imgAttr, { defaults: { width: 700, format: 'avif' } }],
	],
},
```

(Some notes on the contributing experience: no `.gitignore` or lock file is an interesting choice 😁)